### PR TITLE
Remove left-over tests directory from pyformance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ init:
 .PHONY: deps
 deps:
 	. venv/bin/activate; pip install -e .[develop]
+	rm -r venv/lib/python3.7/site-packages/tests
 
 .PHONY: dist
 dist:


### PR DESCRIPTION
Actually doing it in the Makefile is probably better than adding it as a step in README.md